### PR TITLE
Add whitespace between imports.

### DIFF
--- a/book/book.md
+++ b/book/book.md
@@ -10,7 +10,9 @@
 \part{Getting started}
 
 <<[1-2-tracking-changes.md]
+
 <<[1-3-understanding-what-is-being-tracked.md]
+
 <<[1-4-beautiful-commits.md]
 
 \part{Using history}


### PR DESCRIPTION
Paperback drops the first line of the included file if there is no whitespace between the includes.
