### PR TITLE
Add submodules to Makefile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,5 +14,5 @@
 	path = examples/2-3-understand-a-change
 	url = git@github.com:goal-oriented-git-examples/2-3-understand-a-change.git
 [submodule "examples/2-4-searching-the-repository"]
-	path = example/2-4-searching-the-repository
+	path = examples/2-4-searching-the-repository
 	url = git@github.com:goal-oriented-git-examples/2-4-searching-the-repository.git

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,12 @@ stats: $(CHAPTERS) .bundle
 .bundle: Gemfile
 	bundle --path .bundle --binstubs bin/stubs
 
-book/%.md: src/%.md bin/scriptrunner lib/script_runner
+book/%.md: src/%.md bin/scriptrunner lib/script_runner examples
 	bin/scriptrunner $< > $@
+
+examples: .gitmodules
+	git submodule init
+	git submodule update
 
 clean:
 	rm -rf build


### PR DESCRIPTION
When @jessieay kindly tested building the book for me, I noticed that the generated examples were run in the root directory instead of the example directories. This happened because the `Makefile` didn't know how to set up the example submodules.

Setting this up revealed a problem in one of the `.gitmodules` file.
