### PR TITLE
Use custom gitconfig for examples.

### DIFF
--- a/examples/.gitconfig
+++ b/examples/.gitconfig
@@ -1,0 +1,7 @@
+[user]
+  name = George Brocklehurst
+  email = george@georgebrock.com
+[core]
+  editor = /usr/bin/true
+[color]
+  ui = false

--- a/lib/script_runner/script.rb
+++ b/lib/script_runner/script.rb
@@ -33,6 +33,7 @@ module ScriptRunner
       @script_file ||= Tempfile.new('script').tap do |file|
         file.puts %Q{#!/bin/sh\n}
         file.puts %Q{PATH="$PATH:#{bin_path}"}
+        file.puts %Q{HOME="#{home_path}"}
         file << script
         file.close
         File.chmod(0744, file.path)
@@ -64,6 +65,10 @@ module ScriptRunner
 
     def bin_path
       File.expand_path('../../../bin', __FILE__)
+    end
+
+    def home_path
+      File.expand_path('../../../examples', __FILE__)
     end
   end
 end


### PR DESCRIPTION
This means I can avoid my non-default personal preferences leaking into examples, and also that I can make a couple of useful tweaks:
1. Set `core.editor` to true(1) to avoid interactive commands.
2. Set `ui.color` to `false` to avoid breaking TeX with ANSI escape sequences.
