### PR TITLE
Support indented examples

### DIFF
--- a/lib/script_runner/script.rb
+++ b/lib/script_runner/script.rb
@@ -14,7 +14,7 @@ module ScriptRunner
 
     def run
       if input_lines.any?
-        ["```\n", generated_output, "```\n"].flatten
+        indented_output
       else
         []
       end
@@ -23,6 +23,14 @@ module ScriptRunner
     private
 
     attr_reader :input_lines
+
+    def indented_output
+      if indent.length > 0
+        generated_output.map { |line| "    #{indent}#{line}" }
+      else
+        ["```\n", generated_output, "```\n"].flatten
+      end
+    end
 
     def generated_output
       stdout_str, _, _ = Open3.capture3("#{script_file.path} 2>&1")
@@ -70,6 +78,11 @@ module ScriptRunner
 
     def home_path
       File.expand_path('../../../examples', __FILE__)
+    end
+
+    def indent
+      match = Transformer::Regex::SCRIPT.match(input_lines.first)
+      match[:indentation]
     end
   end
 end

--- a/lib/script_runner/transformer.rb
+++ b/lib/script_runner/transformer.rb
@@ -7,6 +7,7 @@ module ScriptRunner
     module Regex
       SCRIPT = %r{
         \A
+        (?<indentation>\s*)
         `
         (?<type>[#{ECHO_TYPE}#{OUTPUT_TYPE}#{SILENT_TYPE}])
         \s+

--- a/spec/script_runner/script_spec.rb
+++ b/spec/script_runner/script_spec.rb
@@ -23,5 +23,17 @@ describe ScriptRunner::Script do
         ]
       end
     end
+
+    context "with an indented script" do
+      it "uses indented output instead of code fencing" do
+        output = described_class.run([
+          %Q(    `! echo "Hello world"\n),
+        ])
+
+        expect(output).to eq [
+          %Q(        Hello world\n)
+        ]
+      end
+    end
   end
 end

--- a/spec/script_runner/transformer_spec.rb
+++ b/spec/script_runner/transformer_spec.rb
@@ -26,5 +26,17 @@ describe ScriptRunner::Transformer do
         Second script output.
       OUTPUT
     end
+
+    it 'matches indented scripts' do
+      input = %Q(    `! echo 'First script.'\n)
+      allow(ScriptRunner::Script).to receive(:run).with([]).and_return([])
+      allow(ScriptRunner::Script).to receive(:run).
+        with([%Q(    `! echo 'First script.'\n)]).
+        and_return(["First script output.\n"])
+
+      output = described_class.new(input).transform
+
+      expect(output).to eq "First script output.\n"
+    end
   end
 end


### PR DESCRIPTION
In some contexts, Markdown code fencing isn't appropriate, and we need to use indentation instead, e.g. when an example is nested within an ordered list.
